### PR TITLE
fix(BehaviorTree): properly copy & clone the IncludeTask guard to the…

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Include.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/decorator/Include.java
@@ -94,12 +94,15 @@ public class Include<E> extends Decorator<E> {
 		Include<E> include = (Include<E>)task;
 		include.subtree = subtree;
 		include.lazy = lazy;
+		include.guard = guard;
 
 		return task;
 	}
 
 	private Task<E> createSubtreeRootTask () {
-		return BehaviorTreeLibraryManager.getInstance().createRootTask(subtree);
+		Task<E> rootTask = BehaviorTreeLibraryManager.getInstance().createRootTask(subtree);
+		rootTask.setGuard(guard);
+		return rootTask;
 	}
 	
 	@Override


### PR DESCRIPTION
There was an issue when using a non-lazy IncludeTask where its guard task will not be cloned/copied whereas it would be if the task was lazy:

```
(needToResetToSpawn?) include subtree:"data/aiBehavioursTree/spawn_reset.btree" // Here the guard will simply be omitted in the final tree  
(needToResetToSpawn?) include subtree:"data/aiBehavioursTree/spawn_reset.btree" lazy:true // Here the guard will be included in the final tree
```