### PR TITLE
Allow private fields on a task to be used as task attribute

### DIFF
--- a/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeParser.java
+++ b/gdx-ai/src/com/badlogic/gdx/ai/btree/utils/BehaviorTreeParser.java
@@ -541,7 +541,7 @@ public class BehaviorTreeParser<E> {
 				if (tca != null) {
 					TaskConstraint taskConstraint = tca.getAnnotation(TaskConstraint.class);
 					ObjectMap<String, AttrInfo> taskAttributes = new ObjectMap<String, AttrInfo>();
-					Field[] fields = ClassReflection.getFields(clazz);
+					Field[] fields = ClassReflection.getDeclaredFields(clazz);
 					for (Field f : fields) {
 						Annotation a = f.getDeclaredAnnotation(TaskAttribute.class);
 						if (a != null) {


### PR DESCRIPTION
The BehaviorTreeParser class only looks for public fields in the task class to process the TaskAttribute annotation. I don't see any reason why we wouldn't want to extends this to private fields as well.